### PR TITLE
Fix `save_training_checkpoint`

### DIFF
--- a/cramming/backend/torch_default.py
+++ b/cramming/backend/torch_default.py
@@ -315,7 +315,7 @@ class TorchEngine(torch.nn.Module):
         except ValueError:
             identifier_str = str(identifier)
         file = os.path.join(directory, f"{identifier:2.4f}.pth")
-        os.makedirs(path, exist_ok=True)
+        os.makedirs(directory, exist_ok=True)
 
         optim_state = self.optimizer.state_dict()
         model_state = self.retrieve_model_state_dict()

--- a/pretrain.py
+++ b/pretrain.py
@@ -62,7 +62,7 @@ def main_training_process(cfg, setup):
 
         # Checkpointing is triggered from stopping criteria and normal intervals
         if cfg.impl.save_intermediate_checkpoints and step % cfg.impl.save_every_nth_step == 0:
-            state = dict(step=step, tokenizer_name=tokenizer.name)
+            state = dict(step=step, tokenizer_name=tokenizer.name_or_path)
             checkpoint_id = loss.item()
             if cramming.utils.is_main_process():
                 model_engine.save_training_checkpoint(checkpoint_id, state=state)


### PR DESCRIPTION
I had to make these two minor changes to get `save_intermediate_checkpoints` to work. 

The first fix is that my `tokenizer` object did not have a `name` attribute, but `tokenizer.name_or_path` exists.

The second fix is that there was no `path` variable in the `save_training_checkpoint(...)` function but a variable named `directory`.

After making these two changes, saving checkpoints worked.