### PR TITLE
Add Support for `torch.compile` During Pretraining for ~15% Speedup

### DIFF
--- a/cramming/architectures/fixed_cramlm.py
+++ b/cramming/architectures/fixed_cramlm.py
@@ -14,6 +14,7 @@ from .components import (
     PoolingComponent,
     PredictionHeadComponent,
 )
+from .utils import maybe_skip_compile
 
 
 def construct_fixed_cramlm(cfg_arch, vocab_size, downstream_classes=None):
@@ -126,7 +127,7 @@ class ScriptableLMForPreTraining(torch.nn.Module):
     # Sparse prediction can have an unpredictable number of entries in each batch
     # depending on how MLM is running
     # for this reason, the code has to fall back to eager mode there
-    # @torchdynamo.disable
+    @maybe_skip_compile()
     def _forward_dynamic(self, outputs: torch.Tensor, labels: Optional[torch.Tensor] = None):
         if labels is not None:
             labels = labels.view(-1)

--- a/cramming/architectures/scriptable_bert.py
+++ b/cramming/architectures/scriptable_bert.py
@@ -18,6 +18,7 @@ from .components import (
     Sequential,
     get_extended_attention_mask,
 )
+from .utils import maybe_skip_compile
 
 
 def construct_scriptable_bert(cfg_arch, vocab_size, downstream_classes=None):
@@ -202,7 +203,7 @@ class ScriptableLMForPreTraining(PreTrainedModel):
     # Sparse prediction can have an unpredictable number of entries in each batch
     # depending on how MLM is running
     # for this reason, the code has to fall back to eager mode there
-    # @torchdynamo.disable
+    @maybe_skip_compile()
     def _forward_dynamic(self, outputs: torch.Tensor, labels: Optional[torch.Tensor] = None):
         if labels is not None:
             labels = labels.view(-1)

--- a/cramming/architectures/utils.py
+++ b/cramming/architectures/utils.py
@@ -1,0 +1,14 @@
+try:
+    # Prevents torch.compile from graph breaking on einops functions. Requires einops>=0.6.1
+    # https://github.com/arogozhnikov/einops/wiki/Using-torch.compile-with-einops
+    from torch._dynamo import allow_in_graph
+    from einops._torch_specific import allow_ops_in_compiled_graph as maybe_allow_einops_compile
+except (ImportError, ModuleNotFoundError):
+    def maybe_allow_einops_compile():
+        pass
+
+try:
+    from torch._dynamo import skip as maybe_skip_compile
+except (ImportError, ModuleNotFoundError):
+    def maybe_skip_compile(cls):
+        return cls

--- a/cramming/config/impl/_default.yaml
+++ b/cramming/config/impl/_default.yaml
@@ -37,6 +37,11 @@ deterministic: False # This option will disable non-deterministic ops
 non_blocking: True # unblocked .to(device) handles
 tf32_allowed: True
 
+# Compile using PyTorch 2.0's `compile`
+compile: False
+compile_backend: inductor
+mode: null
+
 # JIT:
 jit: # Global JIT. Can be "script" (but this doesnt work for huggingface models) or "trace" (but trace does not work with AMP)
 jit_instruction_type: nvfuser-profiler


### PR DESCRIPTION
This PR adds support for using PyTorch 2.0's `torch.compile` during the pretraining task. `torch.compile` is set via a new argument in `_default.yaml`, and is turned off by default.

Using `torch.compile` during pretraining allows for larger batch sizes with the same model settings and when combined results in ~9% increase in throughput on a consumer GPU when compared to PyTorch 1.13.

This PR also adds `PyTorchFlashMultiHeadAttention`, a new attention module which uses PyTorch's `scaled_dot_product_attention` beta implementation of FlashAttention. `scaled_dot_product_attention` doesn't cause any Cuda graph breaks when compiled, leading to an additional ~5% improvement, for a total of ~15% increase in training throughput over PyTorch 1.13's eager mode with FlashAttention.

There are still multiple graph breaks in `ScriptableLMForPreTraining` which this PR does not attempt to resolve. Here is the output from `torch._dynamo.explain`:

```
Dynamo produced 35 graphs with 34 graph break and 117 ops
 Break reasons: 

1. return_value
  File "cramming/architectures/components.py", line 45, in forward
    return self.dropout(self.norm(embeds))
 
2. call_function UserDefinedObjectVariable(partial) [TensorVariable(), TensorVariable(), TensorVariable(), TensorVariable()] {}
  File "cramming/architectures/components.py", line 137, in forward
    states = self.fn_training(states, self.attn(self.norm1(states), attention_mask), self.alpha, res_scale)
 
3. return_value
  File "cramming/architectures/fused_layers.py", line 47, in simplified_layer_training
    return simplified_layer_structure(states, outputs, alpha, residual_scale, prob, training=True)
 
4. call_function UserDefinedObjectVariable(partial) [TensorVariable(), TensorVariable(), TensorVariable(), TensorVariable()] {}
  File "cramming/architectures/components.py", line 138, in <graph break in forward>
    states = self.fn_training(states, self.ffn(self.norm2(states)), self.alpha, res_scale)
 
5. call_function BuiltinVariable(dict) [] {'loss': TensorVariable(), 'logits': TensorVariable()}
  File "cramming/architectures/scriptable_bert.py", line 201, in <graph break in forward>
    return dict(loss=masked_lm_loss, logits=outputs)
```

This PR also does not add support `torch.compile` for the evaluation script. Currently `torch.compile` appears to recompile the evaluation model every training step. I have not looked into why this is occurring.

I have only tested this PR in a single GPU setting.

If you want, I can also update the ReadMe with `torch.compile` instructions.