### PR TITLE
initialize prefetch_factor to None when num_workers is zero

### DIFF
--- a/cramming/backend/utils.py
+++ b/cramming/backend/utils.py
@@ -106,7 +106,7 @@ def prepare_pretraining_dataloader(dataset, tokenizer, cfg_train, cfg_impl):
         num_workers=num_workers,
         pin_memory=cfg_impl.pin_memory,
         drop_last=True,
-        prefetch_factor=cfg_impl.prefetch_factor if num_workers > 0 else 2,
+        prefetch_factor=cfg_impl.prefetch_factor if num_workers > 0 else None,
         persistent_workers=cfg_impl.persistent_workers if num_workers > 0 else False,
         collate_fn=collate_fn,
     )


### PR DESCRIPTION
Hi,
It seems like the 'prefetch_factor' is initialized to 2 when num_of_workers==0,
 (from cramming/cramming/backend/utils, in 'prepare_downstream_dataloader):
 
```
dataloader = DataLoader(
        dataset,
        batch_size=cfg_impl.microbatch_size,
        sampler=sampler,
        num_workers=num_workers,
        pin_memory=cfg_impl.pin_memory,
        drop_last=True if mode == "training" else False,
        prefetch_factor=cfg_impl.prefetch_factor if num_workers > 0 else 2,
        persistent_workers=False,
        collate_fn=collate_fn,
    )
    return dataloader
```
    

However, in the new pytorch versions, you cannot initialize prefetch_factor to anything that isn't None if num_workers==0.
[[link to a relevant issue](https://github.com/pytorch/pytorch/issues/68576) ]

the code:
`        if persistent_workers and num_workers == 0:
raise ValueError('persistent_workers option needs num_workers > 0')` ,

 [from here, in pytorch code](https://github.com/pytorch/pytorch/blob/03de15806e5d27ee4ef6d82dbcc66dac78f6e3bf/torch/utils/data/dataloader.py#L172)
            


Therefore, I changed it to initialize prefetch_factor to None if num_workers<=0.

I added those changes in case you think its relevant to the project,

Thanks