### PR TITLE
Fix pretraining_preparation.py - previously it would die with "BuilderConfig 'train' not found. Available: ['default']"

### DIFF
--- a/cramming/data/pretraining_preparation.py
+++ b/cramming/data/pretraining_preparation.py
@@ -457,7 +457,7 @@ def main_process_first():
 def _load_from_hub(cfg_data, data_path):
     from huggingface_hub import hf_hub_download
 
-    tokenized_dataset = datasets.load_dataset(cfg_data.hf_location, "train", streaming=cfg_data.streaming, cache_dir=data_path)["train"]
+    tokenized_dataset = datasets.load_dataset(cfg_data.hf_location, split="train", streaming=cfg_data.streaming, cache_dir=data_path)["train"]
     tokenized_dataset = tokenized_dataset.with_format("torch")
 
     tokenizer_req_files = ["special_tokens_map.json", "tokenizer.json", "tokenizer_config.json"]


### PR DESCRIPTION
You attempt to load the `train` configuration of the huggingface dataset, but `train` is a split rather than a configuration for pile-readymade, so it complains:

```
Traceback (most recent call last):
  File "/workspace/cramming/pretrain.py", line 196, in launch
    cramming.utils.main_launcher(cfg, main_training_process, job_name="pretraining")
  File "/workspace/cramming/cramming/utils.py", line 54, in main_launcher
    metrics = main_fn(cfg, setup)
  File "/workspace/cramming/pretrain.py", line 21, in main_training_process
    dataset, tokenizer = cramming.load_pretraining_corpus(cfg.data, cfg.impl)
  File "/workspace/cramming/cramming/data/pretraining_preparation.py", line 40, in load_pretraining_corpus
    return _load_from_hub(cfg_data, data_path)
  File "/workspace/cramming/cramming/data/pretraining_preparation.py", line 460, in _load_from_hub
    tokenized_dataset = datasets.load_dataset(cfg_data.hf_location, "train", streaming=cfg_data.streaming, cache_dir=data_path)["train"]
  File "/usr/local/lib/python3.10/dist-packages/datasets/load.py", line 2548, in load_dataset
    builder_instance = load_dataset_builder(
  File "/usr/local/lib/python3.10/dist-packages/datasets/load.py", line 2257, in load_dataset_builder
    builder_instance: DatasetBuilder = builder_cls(
  File "/usr/local/lib/python3.10/dist-packages/datasets/builder.py", line 371, in __init__
    self.config, self.config_id = self._create_builder_config(
  File "/usr/local/lib/python3.10/dist-packages/datasets/builder.py", line 592, in _create_builder_config
    raise ValueError(
ValueError: BuilderConfig 'train' not found. Available: ['default']
```

I've changed it to request the train split instead of a train configuration.